### PR TITLE
Update version number to reflect license change

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssb-legacy-msg-data"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["AljoschaMeyer <mail@aljoscha-meyer.de>"]
 license = "LGPL-3.0"
 description = "Rust implementation of the [ssb legacy data format](https://spec.scuttlebutt.nz/feed/datamodel.html)."


### PR DESCRIPTION
`0.1.3` -> `0.1.4`

Allow us to publish the latest version to crates.io.